### PR TITLE
RobotlegsJS Framework Monorepo

### DIFF
--- a/pages/extensions.md
+++ b/pages/extensions.md
@@ -4,24 +4,24 @@ title: Extensions
 permalink: /extensions/
 ---
 
-- [RobotlegsJS-Macrobot](https://github.com/RobotlegsJS/RobotlegsJS-Macrobot): extends commands, adding support to async and macro commands.
+- [RobotlegsJS-Macrobot](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/macrobot): extends commands, adding support to async and macro commands.
 
-- [RobotlegsJS-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap): maps [SignalsJS](https://github.com/RobotlegsJS/SignalsJS) to commands.
+- [RobotlegsJS-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/signalcommandmap): maps [SignalsJS](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/signals) to commands.
 
-- [RobotlegsJS-EventEmitter3](https://github.com/RobotlegsJS/RobotlegsJS-EventEmitter3): integrate RobotlegsJS with [EventEmitter3](https://github.com/primus/eventemitter3).
+- [RobotlegsJS-EventEmitter3](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/eventemitter3): integrate RobotlegsJS with [EventEmitter3](https://github.com/primus/eventemitter3).
 
-- [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Pixi): integrate RobotlegsJS with [PixiJS](https://github.com/pixijs/pixi.js).
+- [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi): integrate RobotlegsJS with [PixiJS](https://github.com/pixijs/pixi.js).
 
-- [RobotlegsJS-Pixi-Palidor](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-Palidor): a view manager extension for [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Pixi).
+- [RobotlegsJS-Pixi-Palidor](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi-palidor): a view manager extension for [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi).
 
-- [RobotlegsJS-Pixi-SignalMediator](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-SignalMediator): a port of [Robotlegs SignalMediator Extension](https://github.com/MrDodson/robotlegs-extensions-SignalMediator) to TypeScript.
+- [RobotlegsJS-Pixi-SignalMediator](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi-signalmediator): a port of [Robotlegs SignalMediator Extension](https://github.com/MrDodson/robotlegs-extensions-SignalMediator) to TypeScript.
 
-- [RobotlegsJS-CreateJS](https://github.com/RobotlegsJS/RobotlegsJS-CreateJS): integrate RobotlegsJS with [EaselJS](https://github.com/CreateJS/EaselJS).
+- [RobotlegsJS-CreateJS](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/createjs): integrate RobotlegsJS with [EaselJS](https://github.com/CreateJS/EaselJS).
 
-- [RobotlegsJS-OpenFL](https://github.com/RobotlegsJS/RobotlegsJS-OpenFL): integrate RobotlegsJS with [OpenFL](https://github.com/openfl/openfl).
+- [RobotlegsJS-OpenFL](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/openfl): integrate RobotlegsJS with [OpenFL](https://github.com/openfl/openfl).
 
-- [RobotlegsJS-Phaser-CE](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE): integrate RobotlegsJS with [Phaser-CE](https://github.com/photonstorm/phaser-ce).
+- [RobotlegsJS-Phaser-CE](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/phaser-ce): integrate RobotlegsJS with [Phaser-CE](https://github.com/photonstorm/phaser-ce).
 
-- [RobotlegsJS-Phaser-CE-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap): maps [Phaser.Signal](https://photonstorm.github.io/phaser-ce/Phaser.Signal.html) to commands.
+- [RobotlegsJS-Phaser-CE-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/phaser-ce-signalcommandmap): maps [Phaser.Signal](https://photonstorm.github.io/phaser-ce/Phaser.Signal.html) to commands.
 
-- [RobotlegsJS-Phaser](https://github.com/RobotlegsJS/RobotlegsJS-Phaser): integrate RobotlegsJS with [Phaser](https://github.com/photonstorm/phaser).
+- [RobotlegsJS-Phaser](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/phaser): integrate RobotlegsJS with [Phaser](https://github.com/photonstorm/phaser).

--- a/pages/getstarted.md
+++ b/pages/getstarted.md
@@ -4,14 +4,15 @@ title: Get started
 permalink: /get_started/
 ---
 
-RobotlegsJS is a architecture-based IoC framework for JavaScript/TypeScript. This
-version is a direct port from the [ActionScript 3.0 codebase](https://github.com/robotlegs/robotlegs-framework).
+RobotlegsJS is a architecture-based IoC framework for JavaScript/TypeScript. This version is a direct port from the [ActionScript 3.0 codebase](https://github.com/robotlegs/robotlegs-framework).
 See the [motivation](#motivation) behind it.
 
-Right now, this framework has extensions for [pixi.js v4](https://github.com/pixijs/pixi.js), [easeljs](https://github.com/CreateJS/EaselJS),
+Right now, this framework has extensions for [pixi.js v5](https://github.com/pixijs/pixi.js), [easeljs](https://github.com/CreateJS/EaselJS),
 [openfl](https://github.com/openfl/openfl), [phaser-ce v2](https://github.com/photonstorm/phaser-ce) and [phaser v3](https://github.com/photonstorm/phaser).
 
 Would you like to integrate RobotlegsJS core with another HTML5/JavaScript framework or library? Send us a message through [Gitter](https://gitter.im/RobotlegsJS/RobotlegsJS) or [Email](mailto:contact@robotlegsjs.io).
+
+You can also fork our [RobotlegsJS Framework](https://github.com/RobotlegsJS/RobotlegsJS-Framework) repository to submit pull requests with your suggestions of new extensions or plugins. Please read our [contributing guidelines](https://github.com/RobotlegsJS/RobotlegsJS-Framework/blob/master/.github/CONTRIBUTING.md) to know more.
 
 # Features
 
@@ -21,29 +22,29 @@ Would you like to integrate RobotlegsJS core with another HTML5/JavaScript frame
 
 - View management
 
-# Extensions
+**Extensions**
 
-- [RobotlegsJS-Macrobot](https://github.com/RobotlegsJS/RobotlegsJS-Macrobot): extends commands, adding support to async and macro commands.
+- [RobotlegsJS-Macrobot](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/macrobot): extends commands, adding support to async and macro commands.
 
-- [RobotlegsJS-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap): maps [SignalsJS](https://github.com/RobotlegsJS/SignalsJS) to commands.
+- [RobotlegsJS-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/signalcommandmap): maps [SignalsJS](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/signals) to commands.
 
-- [RobotlegsJS-EventEmitter3](https://github.com/RobotlegsJS/RobotlegsJS-EventEmitter3): integrate RobotlegsJS with [EventEmitter3](https://github.com/primus/eventemitter3).
+- [RobotlegsJS-EventEmitter3](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/eventemitter3): integrate RobotlegsJS with [EventEmitter3](https://github.com/primus/eventemitter3).
 
-- [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Pixi): integrate RobotlegsJS with [PixiJS](https://github.com/pixijs/pixi.js).
+- [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi): integrate RobotlegsJS with [PixiJS](https://github.com/pixijs/pixi.js).
 
-- [RobotlegsJS-Pixi-Palidor](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-Palidor): a view manager extension for [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Pixi).
+- [RobotlegsJS-Pixi-Palidor](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi-palidor): a view manager extension for [RobotlegsJS-Pixi](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi).
 
-- [RobotlegsJS-Pixi-SignalMediator](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-SignalMediator): a port of [Robotlegs SignalMediator Extension](https://github.com/MrDodson/robotlegs-extensions-SignalMediator) to TypeScript.
+- [RobotlegsJS-Pixi-SignalMediator](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/pixi-signalmediator): a port of [Robotlegs SignalMediator Extension](https://github.com/MrDodson/robotlegs-extensions-SignalMediator) to TypeScript.
 
-- [RobotlegsJS-CreateJS](https://github.com/RobotlegsJS/RobotlegsJS-CreateJS): integrate RobotlegsJS with [EaselJS](https://github.com/CreateJS/EaselJS).
+- [RobotlegsJS-CreateJS](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/createjs): integrate RobotlegsJS with [EaselJS](https://github.com/CreateJS/EaselJS).
 
-- [RobotlegsJS-OpenFL](https://github.com/RobotlegsJS/RobotlegsJS-OpenFL): integrate RobotlegsJS with [OpenFL](https://github.com/openfl/openfl).
+- [RobotlegsJS-OpenFL](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/openfl): integrate RobotlegsJS with [OpenFL](https://github.com/openfl/openfl).
 
-- [RobotlegsJS-Phaser-CE](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE): integrate RobotlegsJS with [Phaser-CE](https://github.com/photonstorm/phaser-ce).
+- [RobotlegsJS-Phaser-CE](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/phaser-ce): integrate RobotlegsJS with [Phaser-CE](https://github.com/photonstorm/phaser-ce).
 
-- [RobotlegsJS-Phaser-CE-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap): maps [Phaser.Signal](https://photonstorm.github.io/phaser-ce/Phaser.Signal.html) to commands.
+- [RobotlegsJS-Phaser-CE-SignalCommandMap](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/phaser-ce-signalcommandmap): maps [Phaser.Signal](https://photonstorm.github.io/phaser-ce/Phaser.Signal.html) to commands.
 
-- [RobotlegsJS-Phaser](https://github.com/RobotlegsJS/RobotlegsJS-Phaser): integrate RobotlegsJS with [Phaser](https://github.com/photonstorm/phaser).
+- [RobotlegsJS-Phaser](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/packages/phaser): integrate RobotlegsJS with [Phaser](https://github.com/photonstorm/phaser).
 
 # Motivation
 
@@ -56,4 +57,4 @@ community for interactive experiences.
 
 # License
 
-[MIT](https://github.com/RobotlegsJS/RobotlegsJS/blob/master/LICENSE)
+[MIT](https://github.com/RobotlegsJS/RobotlegsJS-Framework/tree/master/LICENSE)

--- a/pages/support.md
+++ b/pages/support.md
@@ -6,80 +6,8 @@ permalink: /support/
 
 The RobotlegsJS development team is dedicated to the support of its users. We keep an eye on Github to try to answer questions and resolve technical issues as soon as we can. Please use the following links if you need any kind of assitance:
 
-SignalsJS
+RobotlegsJS Framework
 ===
 
-- [See all SignalsJS issues on GitHub](https://github.com/RobotlegsJS/SignalsJS/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/SignalsJS/issues/new)
-
-RobotlegsJS
-===
-
-- [See all RobotlegsJS issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS/issues/new)
-
-RobotlegsJS-Macrobot
-===
-
-- [See all RobotlegsJS-Macrobot issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Macrobot/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Macrobot/issues/new)
-
-RobotlegsJS-SignalCommandMap
-===
-
-- [See all RobotlegsJS-SignalCommandMap issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-SignalCommandMap/issues/new)
-
-RobotlegsJS-EventEmitter3
-===
-
-- [See all RobotlegsJS-EventEmitter3 issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-EventEmitter3/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-EventEmitter3/issues/new)
-
-RobotlegsJS-Pixi
-===
-
-- [See all RobotlegsJS-Pixi issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Pixi/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Pixi/issues/new)
-
-RobotlegsJS-Pixi-Palidor
-===
-
-- [See all RobotlegsJS-Pixi-Palidor issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-Palidor/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-Palidor/issues/new)
-
-RobotlegsJS-Pixi-SignalMediator
-===
-
-- [See all RobotlegsJS-Pixi-SignalMediator issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-SignalMediator/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Pixi-SignalMediator/issues/new)
-
-RobotlegsJS-CreateJS
-===
-
-- [See all RobotlegsJS-CreateJS issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-CreateJS/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-CreateJS/issues/new)
-
-RobotlegsJS-OpenFL
-===
-
-- [See all RobotlegsJS-OpenFL issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-OpenFL/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-OpenFL/issues/new)
-
-RobotlegsJS-Phaser-CE
-===
-
-- [See all RobotlegsJS-Phaser-CE issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE/issues/new)
-
-RobotlegsJS-Phaser-CE-SignalCommandMap
-===
-
-- [See all RobotlegsJS-Phaser-CE-SignalCommandMap issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Phaser-CE-SignalCommandMap/issues/new)
-
-RobotlegsJS-Phaser
-===
-
-- [See all RobotlegsJS-Phaser issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/issues?utf8=%E2%9C%93&q=is%3Aissue)
-- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Phaser/issues/new)
+- [See all RobotlegsJS Framework issues on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Framework/issues?utf8=%E2%9C%93&q=is%3Aissue)
+- [Repport an issue on GitHub](https://github.com/RobotlegsJS/RobotlegsJS-Framework/issues/new/choose)


### PR DESCRIPTION
Update links to [RobotlegsJS Framework](https://github.com/RobotlegsJS/RobotlegsJS-Framework)